### PR TITLE
Update to jupyterlab_chat

### DIFF
--- a/packages/jupyter-ai-module-cookiecutter/{{cookiecutter.root_dir_name}}/{{cookiecutter.python_name}}/slash_command.py
+++ b/packages/jupyter-ai-module-cookiecutter/{{cookiecutter.root_dir_name}}/{{cookiecutter.python_name}}/slash_command.py
@@ -2,7 +2,7 @@ from jupyter_ai.chat_handlers.base import BaseChatHandler, SlashCommandRoutingTy
 from jupyter_ai.models import HumanChatMessage
 
 try:
-    from jupyterlab_collaborative_chat.ychat import YChat
+    from jupyterlab_chat.ychat import YChat
 except:
     from typing import Any as YChat
 

--- a/packages/jupyter-ai-test/jupyter_ai_test/test_slash_commands.py
+++ b/packages/jupyter-ai-test/jupyter_ai_test/test_slash_commands.py
@@ -2,7 +2,7 @@ from jupyter_ai.chat_handlers.base import BaseChatHandler, SlashCommandRoutingTy
 from jupyter_ai.models import HumanChatMessage
 
 try:
-    from jupyterlab_collaborative_chat.ychat import YChat
+    from jupyterlab_chat.ychat import YChat
 except:
     from typing import Any as YChat
 

--- a/packages/jupyter-ai/jupyter_ai/chat_handlers/__init__.py
+++ b/packages/jupyter-ai/jupyter_ai/chat_handlers/__init__.py
@@ -1,5 +1,5 @@
 # The following import is to make sure jupyter_ydoc is imported before
-# jupyterlab_collaborative_chat, otherwise it leads to circular import because of the
+# jupyterlab_chat, otherwise it leads to circular import because of the
 # YChat relying on YBaseDoc, and jupyter_ydoc registering YChat from the entry point.
 import jupyter_ydoc
 

--- a/packages/jupyter-ai/jupyter_ai/chat_handlers/ask.py
+++ b/packages/jupyter-ai/jupyter_ai/chat_handlers/ask.py
@@ -8,7 +8,7 @@ from langchain.memory import ConversationBufferWindowMemory
 from langchain_core.prompts import PromptTemplate
 
 try:
-    from jupyterlab_collaborative_chat.ychat import YChat
+    from jupyterlab_chat.ychat import YChat
 except:
     from typing import Any as YChat
 

--- a/packages/jupyter-ai/jupyter_ai/chat_handlers/base.py
+++ b/packages/jupyter-ai/jupyter_ai/chat_handlers/base.py
@@ -45,7 +45,7 @@ from langchain_core.runnables.config import merge_configs as merge_runnable_conf
 from langchain_core.runnables.utils import Input
 
 try:
-    from jupyterlab_collaborative_chat.ychat import YChat
+    from jupyterlab_chat.ychat import YChat
 except:
     from typing import Any as YChat
 
@@ -392,7 +392,7 @@ class BaseChatHandler:
         Context manager that sends a pending message to the client, and closes
         it after the block is executed.
 
-        TODO: Simplify it by only modifying the awareness as soon as collaborative chat
+        TODO: Simplify it by only modifying the awareness as soon as jupyterlab chat
         is the only used chat.
         """
         pending_msg = self.start_pending(text, human_msg=human_msg, chat=chat, ellipsis=ellipsis)

--- a/packages/jupyter-ai/jupyter_ai/chat_handlers/clear.py
+++ b/packages/jupyter-ai/jupyter_ai/chat_handlers/clear.py
@@ -3,7 +3,7 @@ from typing import Optional
 from jupyter_ai.models import ClearRequest
 
 try:
-    from jupyterlab_collaborative_chat.ychat import YChat
+    from jupyterlab_chat.ychat import YChat
 except:
     from typing import Any as YChat
 

--- a/packages/jupyter-ai/jupyter_ai/chat_handlers/default.py
+++ b/packages/jupyter-ai/jupyter_ai/chat_handlers/default.py
@@ -7,7 +7,7 @@ from langchain_core.runnables import ConfigurableFieldSpec
 from langchain_core.runnables.history import RunnableWithMessageHistory
 
 try:
-    from jupyterlab_collaborative_chat.ychat import YChat
+    from jupyterlab_chat.ychat import YChat
 except:
     from typing import Any as YChat
 

--- a/packages/jupyter-ai/jupyter_ai/chat_handlers/export.py
+++ b/packages/jupyter-ai/jupyter_ai/chat_handlers/export.py
@@ -6,7 +6,7 @@ from typing import List, Optional
 from jupyter_ai.models import AgentChatMessage, AgentStreamMessage, HumanChatMessage
 
 try:
-    from jupyterlab_collaborative_chat.ychat import YChat
+    from jupyterlab_chat.ychat import YChat
 except:
     from typing import Any as YChat
 

--- a/packages/jupyter-ai/jupyter_ai/chat_handlers/fix.py
+++ b/packages/jupyter-ai/jupyter_ai/chat_handlers/fix.py
@@ -5,7 +5,7 @@ from jupyter_ai_magics.providers import BaseProvider
 from langchain.prompts import PromptTemplate
 
 try:
-    from jupyterlab_collaborative_chat.ychat import YChat
+    from jupyterlab_chat.ychat import YChat
 except:
     from typing import Any as YChat
 

--- a/packages/jupyter-ai/jupyter_ai/chat_handlers/generate.py
+++ b/packages/jupyter-ai/jupyter_ai/chat_handlers/generate.py
@@ -17,7 +17,7 @@ from langchain.schema.output_parser import BaseOutputParser
 from langchain_core.prompts import PromptTemplate
 
 try:
-    from jupyterlab_collaborative_chat.ychat import YChat
+    from jupyterlab_chat.ychat import YChat
 except:
     from typing import Any as YChat
 

--- a/packages/jupyter-ai/jupyter_ai/chat_handlers/help.py
+++ b/packages/jupyter-ai/jupyter_ai/chat_handlers/help.py
@@ -3,7 +3,7 @@ from typing import Optional
 from jupyter_ai.models import HumanChatMessage
 
 try:
-    from jupyterlab_collaborative_chat.ychat import YChat
+    from jupyterlab_chat.ychat import YChat
 except:
     from typing import Any as YChat
 

--- a/packages/jupyter-ai/jupyter_ai/chat_handlers/learn.py
+++ b/packages/jupyter-ai/jupyter_ai/chat_handlers/learn.py
@@ -31,7 +31,7 @@ from langchain.text_splitter import (
 from langchain_community.vectorstores import FAISS
 
 try:
-    from jupyterlab_collaborative_chat.ychat import YChat
+    from jupyterlab_chat.ychat import YChat
 except:
     from typing import Any as YChat
 

--- a/packages/jupyter-ai/jupyter_ai/extension.py
+++ b/packages/jupyter-ai/jupyter_ai/extension.py
@@ -17,7 +17,7 @@ from jupyter_collaboration.utils import JUPYTER_COLLABORATION_EVENTS_URI
 from jupyter_events import EventLogger
 from jupyter_server.extension.application import ExtensionApp
 from jupyter_server.utils import url_path_join
-from jupyterlab_collaborative_chat.ychat import YChat
+from jupyterlab_chat.ychat import YChat
 from pycrdt import ArrayEvent
 from tornado.web import StaticFileHandler
 from traitlets import Dict, Integer, List, Unicode

--- a/packages/jupyter-ai/package.json
+++ b/packages/jupyter-ai/package.json
@@ -61,7 +61,7 @@
   "dependencies": {
     "@emotion/react": "^11.10.5",
     "@emotion/styled": "^11.10.5",
-    "@jupyter/chat": "^0.5.0",
+    "@jupyter/chat": "^0.6.0",
     "@jupyter/collaboration": "^1",
     "@jupyterlab/application": "^4.2.0",
     "@jupyterlab/apputils": "^4.2.0",

--- a/packages/jupyter-ai/pyproject.toml
+++ b/packages/jupyter-ai/pyproject.toml
@@ -35,7 +35,7 @@ dependencies = [
     "typing_extensions>=4.5.0",
     "traitlets>=5.0",
     "deepmerge>=2.0,<3",
-    "jupyterlab-collaborative-chat>=0.5.0",
+    "jupyterlab-chat>=0.6.0",
 ]
 
 dynamic = ["version", "description", "authors", "urls", "keywords"]

--- a/packages/jupyter-ai/src/components/chat-settings.tsx
+++ b/packages/jupyter-ai/src/components/chat-settings.tsx
@@ -34,7 +34,7 @@ type ChatSettingsProps = {
   rmRegistry: IRenderMimeRegistry;
   completionProvider: IJaiCompletionProvider | null;
   openInlineCompleterSettings: () => void;
-  // The temporary input options,  should be removed when the collaborative chat is
+  // The temporary input options,  should be removed when jupyterlab chat is
   // the only chat.
   inputOptions?: boolean;
 };
@@ -514,7 +514,7 @@ export function ChatSettings(props: ChatSettingsProps): JSX.Element {
         onSuccess={server.refetchApiKeys}
       />
 
-      {/* Input - to remove when the collaborative chat is the only chat */}
+      {/* Input - to remove when jupyterlab chat is the only chat */}
       {(props.inputOptions ?? true) && (
         <>
           <h2 className="jp-ai-ChatSettings-header">Input</h2>

--- a/packages/jupyter-ai/src/index.ts
+++ b/packages/jupyter-ai/src/index.ts
@@ -184,9 +184,9 @@ const plugin: JupyterFrontEndPlugin<IJaiCore> = {
 };
 
 /**
- * Add slash commands to collaborative chat.
+ * Add slash commands to jupyterlab chat.
  */
-const collaborative_autocompletion: JupyterFrontEndPlugin<void> = {
+const chat_autocompletion: JupyterFrontEndPlugin<void> = {
   id: '@jupyter-ai/core:autocompletion',
   autoStart: true,
   requires: [IAutocompletionRegistry],
@@ -203,7 +203,7 @@ export default [
   statusItemPlugin,
   completionPlugin,
   menuPlugin,
-  collaborative_autocompletion
+  chat_autocompletion
 ];
 
 export * from './contexts';

--- a/yarn.lock
+++ b/yarn.lock
@@ -2220,7 +2220,7 @@ __metadata:
     "@babel/preset-env": ^7.0.0
     "@emotion/react": ^11.10.5
     "@emotion/styled": ^11.10.5
-    "@jupyter/chat": ^0.5.0
+    "@jupyter/chat": ^0.6.0
     "@jupyter/collaboration": ^1
     "@jupyterlab/application": ^4.2.0
     "@jupyterlab/apputils": ^4.2.0
@@ -2286,9 +2286,9 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@jupyter/chat@npm:^0.5.0":
-  version: 0.5.0
-  resolution: "@jupyter/chat@npm:0.5.0"
+"@jupyter/chat@npm:^0.6.0":
+  version: 0.6.0
+  resolution: "@jupyter/chat@npm:0.6.0"
   dependencies:
     "@emotion/react": ^11.10.5
     "@emotion/styled": ^11.10.5
@@ -2307,7 +2307,7 @@ __metadata:
     clsx: ^2.1.0
     react: ^18.2.0
     react-dom: ^18.2.0
-  checksum: 0c935344e3cf8b60ded1df83c1b608f77becd7ea8c82c175a8588606c6c56a46525130b429b5acfaab441d9ccac9d478b25646bdb8aa3dfd1af82c8f372e07cf
+  checksum: 1af125488113fbe9089014ae2fd6bf39f5645e6a8387ee513cbae2ed24183ebd6611347e6c6bca05832a6d90fdb001ebce508f7b08e3ae92edd9946b9253dec9
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This PR replace the former extension `jupyterlab_collaborative_chat` by `jupyterlab_chat`.