### PR TITLE
Dedicate one set of chat handlers per room

### DIFF
--- a/packages/jupyter-ai-test/jupyter_ai_test/test_slash_commands.py
+++ b/packages/jupyter-ai-test/jupyter_ai_test/test_slash_commands.py
@@ -1,6 +1,5 @@
 from jupyter_ai.chat_handlers.base import BaseChatHandler, SlashCommandRoutingType
 from jupyter_ai.models import HumanChatMessage
-from jupyterlab_chat.ychat import YChat
 
 
 class TestSlashCommand(BaseChatHandler):
@@ -26,5 +25,5 @@ class TestSlashCommand(BaseChatHandler):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
-    async def process_message(self, message: HumanChatMessage, chat: YChat):
-        self.reply("This is the `/test` slash command.", chat)
+    async def process_message(self, message: HumanChatMessage):
+        self.reply("This is the `/test` slash command.")

--- a/packages/jupyter-ai/jupyter_ai/chat_handlers/base.py
+++ b/packages/jupyter-ai/jupyter_ai/chat_handlers/base.py
@@ -8,7 +8,6 @@ from typing import (
     TYPE_CHECKING,
     Any,
     Awaitable,
-    Callable,
     ClassVar,
     Dict,
     List,
@@ -24,6 +23,7 @@ from uuid import uuid4
 from dask.distributed import Client as DaskClient
 from jupyter_ai.callback_handlers import MetadataCallbackHandler
 from jupyter_ai.config_manager import ConfigManager, Logger
+from jupyter_ai.constants import BOT
 from jupyter_ai.history import WrappedBoundedChatHistory
 from jupyter_ai.models import (
     AgentChatMessage,
@@ -158,7 +158,7 @@ class BaseChatHandler:
         chat_handlers: Dict[str, "BaseChatHandler"],
         context_providers: Dict[str, "BaseCommandContextProvider"],
         message_interrupted: Dict[str, asyncio.Event],
-        write_message: Callable[[YChat, str, Optional[str]], str],
+        ychat: Optional[YChat],
     ):
         self.log = log
         self.config_manager = config_manager
@@ -181,14 +181,20 @@ class BaseChatHandler:
         self.chat_handlers = chat_handlers
         self.context_providers = context_providers
         self.message_interrupted = message_interrupted
+        self.ychat = ychat
+        self.indexes_by_id: Dict[str, str] = {}
+        """
+        Indexes of messages in the YChat document by message ID.
+
+        TODO: Remove this once `jupyterlab-chat` can update messages by ID
+        without an index.
+        """
 
         self.llm: Optional[BaseProvider] = None
         self.llm_params: Optional[dict] = None
         self.llm_chain: Optional[Runnable] = None
 
-        self.write_message = write_message
-
-    async def on_message(self, message: HumanChatMessage, chat: Optional[YChat] = None):
+    async def on_message(self, message: HumanChatMessage):
         """
         Method which receives a human message, calls `self.get_llm_chain()`, and
         processes the message via `self.process_message()`, calling
@@ -204,7 +210,6 @@ class BaseChatHandler:
             if slash_command in lm_provider_klass.unsupported_slash_commands:
                 self.reply(
                     "Sorry, the selected language model does not support this slash command.",
-                    chat,
                 )
                 return
 
@@ -216,7 +221,6 @@ class BaseChatHandler:
             if not lm_provider.allows_concurrency:
                 self.reply(
                     "The currently selected language model can process only one request at a time. Please wait for me to reply before sending another question.",
-                    chat,
                     message,
                 )
                 return
@@ -224,24 +228,24 @@ class BaseChatHandler:
         BaseChatHandler._requests_count += 1
 
         if self.__class__.supports_help:
-            args = self.parse_args(message, chat, silent=True)
+            args = self.parse_args(message, silent=True)
             if args and args.help:
-                self.reply(self.parser.format_help(), chat, message)
+                self.reply(self.parser.format_help(), message)
                 return
 
         try:
-            await self.process_message(message, chat)
+            await self.process_message(message)
         except Exception as e:
             try:
                 # we try/except `handle_exc()` in case it was overriden and
                 # raises an exception by accident.
-                await self.handle_exc(e, message, chat)
+                await self.handle_exc(e, message)
             except Exception as e:
-                await self._default_handle_exc(e, message, chat)
+                await self._default_handle_exc(e, message)
         finally:
             BaseChatHandler._requests_count -= 1
 
-    async def process_message(self, message: HumanChatMessage, chat: Optional[YChat]):
+    async def process_message(self, message: HumanChatMessage):
         """
         Processes a human message routed to this chat handler. Chat handlers
         (subclasses) must implement this method. Don't forget to call
@@ -253,17 +257,17 @@ class BaseChatHandler:
         raise NotImplementedError("Should be implemented by subclasses.")
 
     async def handle_exc(
-        self, e: Exception, message: HumanChatMessage, chat: Optional[YChat]
+        self, e: Exception, message: HumanChatMessage
     ):
         """
         Handles an exception raised by `self.process_message()`. A default
         implementation is provided, however chat handlers (subclasses) should
         implement this method to provide a more helpful error response.
         """
-        await self._default_handle_exc(e, message, chat)
+        await self._default_handle_exc(e, message)
 
     async def _default_handle_exc(
-        self, e: Exception, message: HumanChatMessage, chat: Optional[YChat]
+        self, e: Exception, message: HumanChatMessage
     ):
         """
         The default definition of `handle_exc()`. This is the default used when
@@ -274,19 +278,49 @@ class BaseChatHandler:
         if lm_provider and lm_provider.is_api_key_exc(e):
             provider_name = getattr(self.config_manager.lm_provider, "name", "")
             response = f"Oops! There's a problem connecting to {provider_name}. Please update your {provider_name} API key in the chat settings."
-            self.reply(response, chat, message)
+            self.reply(response, message)
             return
         formatted_e = traceback.format_exc()
         response = (
             f"Sorry, an error occurred. Details below:\n\n```\n{formatted_e}\n```"
         )
-        self.reply(response, chat, message)
+        self.reply(response, message)
+    
+    def write_message(self, body: str, id: Optional[str] = None) -> None:
+        """[Jupyter Chat only] Writes a message to the YChat shared document
+        that this chat handler is assigned to."""
+        if not self.ychat:
+            return
+        
+        bot = self.ychat.get_user(BOT["username"])
+        if not bot:
+            self.ychat.set_user(BOT)
+
+        index = self.indexes_by_id.get(id, None)
+        id = id if id else str(uuid4())
+        new_index = self.ychat.set_message(
+            {
+                "type": "msg",
+                "body": body,
+                "id": id if id else str(uuid4()),
+                "time": time.time(),
+                "sender": BOT["username"],
+                "raw_time": False,
+            },
+            index=index,
+            append=True,
+        )
+
+        self.indexes_by_id[id] = new_index
+        return id
 
     def broadcast_message(self, message: Message):
         """
         Broadcasts a message to all WebSocket connections. If there are no
         WebSocket connections and the message is a chat message, this method
         directly appends to `self.chat_history`.
+
+        TODO: Remove this after Jupyter Chat migration is complete.
         """
         broadcast = False
         for websocket in self._root_chat_handlers.values():
@@ -305,15 +339,14 @@ class BaseChatHandler:
     def reply(
         self,
         response: str,
-        chat: Optional[YChat],
         human_msg: Optional[HumanChatMessage] = None,
     ):
         """
         Sends an agent message, usually in response to a received
         `HumanChatMessage`.
         """
-        if chat is not None:
-            self.write_message(chat, response, None)
+        if self.ychat is not None:
+            self.write_message(response, None)
         else:
             agent_msg = AgentChatMessage(
                 id=uuid4().hex,
@@ -333,7 +366,6 @@ class BaseChatHandler:
         text: str,
         human_msg: Optional[HumanChatMessage] = None,
         *,
-        chat: Optional[YChat] = None,
         ellipsis: bool = True,
     ) -> PendingMessage:
         """
@@ -352,13 +384,13 @@ class BaseChatHandler:
             ellipsis=ellipsis,
         )
 
-        if chat is not None and chat.awareness is not None:
-            chat.awareness.set_local_state_field("isWriting", True)
+        if self.ychat is not None and self.ychat.awareness is not None:
+            self.ychat.awareness.set_local_state_field("isWriting", True)
         else:
             self.broadcast_message(pending_msg)
         return pending_msg
 
-    def close_pending(self, pending_msg: PendingMessage, chat: Optional[YChat] = None):
+    def close_pending(self, pending_msg: PendingMessage):
         """
         Closes a pending message.
         """
@@ -369,8 +401,8 @@ class BaseChatHandler:
             id=pending_msg.id,
         )
 
-        if chat is not None and chat.awareness is not None:
-            chat.awareness.set_local_state_field("isWriting", False)
+        if self.ychat is not None and self.ychat.awareness is not None:
+            self.ychat.awareness.set_local_state_field("isWriting", False)
         else:
             self.broadcast_message(close_pending_msg)
         pending_msg.closed = True
@@ -381,7 +413,6 @@ class BaseChatHandler:
         text: str,
         human_msg: Optional[HumanChatMessage] = None,
         *,
-        chat: Optional[YChat] = None,
         ellipsis: bool = True,
     ):
         """
@@ -392,13 +423,13 @@ class BaseChatHandler:
         is the only used chat.
         """
         pending_msg = self.start_pending(
-            text, human_msg=human_msg, chat=chat, ellipsis=ellipsis
+            text, human_msg=human_msg, ellipsis=ellipsis
         )
         try:
             yield pending_msg
         finally:
             if not pending_msg.closed:
-                self.close_pending(pending_msg, chat=chat)
+                self.close_pending(pending_msg)
 
     def get_llm_chain(self):
         lm_provider = self.config_manager.lm_provider
@@ -440,14 +471,14 @@ class BaseChatHandler:
     ):
         raise NotImplementedError("Should be implemented by subclasses")
 
-    def parse_args(self, message, chat, silent=False):
+    def parse_args(self, message, silent=False):
         args = message.body.split(" ")
         try:
             args = self.parser.parse_args(args[1:])
         except (argparse.ArgumentError, SystemExit) as e:
             if not silent:
                 response = f"{self.parser.format_usage()}"
-                self.reply(response, chat, message)
+                self.reply(response, message)
             return None
         return args
 
@@ -471,7 +502,7 @@ class BaseChatHandler:
             return self.root_dir
 
     def send_help_message(
-        self, chat: Optional[YChat], human_msg: Optional[HumanChatMessage] = None
+        self, human_msg: Optional[HumanChatMessage] = None
     ) -> None:
         """Sends a help message to all connected clients."""
         lm_provider = self.config_manager.lm_provider
@@ -504,8 +535,8 @@ class BaseChatHandler:
             context_commands_list=context_commands_list,
         )
 
-        if chat is not None:
-            self.write_message(chat, help_message_body, None)
+        if self.ychat is not None:
+            self.write_message(help_message_body, None)
         else:
             help_message = AgentChatMessage(
                 id=uuid4().hex,
@@ -516,13 +547,13 @@ class BaseChatHandler:
             )
             self.broadcast_message(help_message)
 
-    def _start_stream(self, human_msg: HumanChatMessage, chat: Optional[YChat]) -> str:
+    def _start_stream(self, human_msg: HumanChatMessage) -> str:
         """
         Sends an `agent-stream` message to indicate the start of a response
         stream. Returns the ID of the message, denoted as the `stream_id`.
         """
-        if chat is not None:
-            stream_id = self.write_message(chat, "", None)
+        if self.ychat is not None:
+            stream_id = self.write_message("", None)
         else:
             stream_id = uuid4().hex
             stream_msg = AgentStreamMessage(
@@ -542,7 +573,6 @@ class BaseChatHandler:
         self,
         stream_id: str,
         content: str,
-        chat: Optional[YChat],
         complete: bool = False,
         metadata: Optional[Dict[str, Any]] = None,
     ) -> None:
@@ -550,8 +580,8 @@ class BaseChatHandler:
         Sends an `agent-stream-chunk` message containing content that should be
         appended to an existing `agent-stream` message with ID `stream_id`.
         """
-        if chat is not None:
-            self.write_message(chat, content, stream_id)
+        if self.ychat is not None:
+            self.write_message(content, stream_id)
         else:
             if not metadata:
                 metadata = {}
@@ -568,7 +598,6 @@ class BaseChatHandler:
         self,
         input: Input,
         human_msg: HumanChatMessage,
-        chat: Optional[YChat],
         pending_msg="Generating response",
         config: Optional[RunnableConfig] = None,
     ):
@@ -603,7 +632,7 @@ class BaseChatHandler:
         merged_config: RunnableConfig = merge_runnable_configs(base_config, config)
 
         # start with a pending message
-        with self.pending(pending_msg, human_msg, chat=chat) as pending_message:
+        with self.pending(pending_msg, human_msg) as pending_message:
             # stream response in chunks. this works even if a provider does not
             # implement streaming, as `astream()` defaults to yielding `_call()`
             # when `_stream()` is not implemented on the LLM class.
@@ -613,8 +642,8 @@ class BaseChatHandler:
                 if not received_first_chunk:
                     # when receiving the first chunk, close the pending message and
                     # start the stream.
-                    self.close_pending(pending_message, chat=chat)
-                    stream_id = self._start_stream(human_msg=human_msg, chat=chat)
+                    self.close_pending(pending_message)
+                    stream_id = self._start_stream(human_msg=human_msg)
                     received_first_chunk = True
                     self.message_interrupted[stream_id] = asyncio.Event()
 
@@ -637,9 +666,9 @@ class BaseChatHandler:
                     break
 
                 if isinstance(chunk, AIMessageChunk) and isinstance(chunk.content, str):
-                    self._send_stream_chunk(stream_id, chunk.content, chat=chat)
+                    self._send_stream_chunk(stream_id, chunk.content)
                 elif isinstance(chunk, str):
-                    self._send_stream_chunk(stream_id, chunk, chat=chat)
+                    self._send_stream_chunk(stream_id, chunk)
                 else:
                     self.log.error(f"Unrecognized type of chunk yielded: {type(chunk)}")
                     break
@@ -651,7 +680,6 @@ class BaseChatHandler:
             self._send_stream_chunk(
                 stream_id,
                 stream_tombstone,
-                chat=chat,
                 complete=True,
                 metadata=metadata_handler.jai_metadata,
             )

--- a/packages/jupyter-ai/jupyter_ai/chat_handlers/base.py
+++ b/packages/jupyter-ai/jupyter_ai/chat_handlers/base.py
@@ -256,9 +256,7 @@ class BaseChatHandler:
         """
         raise NotImplementedError("Should be implemented by subclasses.")
 
-    async def handle_exc(
-        self, e: Exception, message: HumanChatMessage
-    ):
+    async def handle_exc(self, e: Exception, message: HumanChatMessage):
         """
         Handles an exception raised by `self.process_message()`. A default
         implementation is provided, however chat handlers (subclasses) should
@@ -266,9 +264,7 @@ class BaseChatHandler:
         """
         await self._default_handle_exc(e, message)
 
-    async def _default_handle_exc(
-        self, e: Exception, message: HumanChatMessage
-    ):
+    async def _default_handle_exc(self, e: Exception, message: HumanChatMessage):
         """
         The default definition of `handle_exc()`. This is the default used when
         the `handle_exc()` excepts.
@@ -285,13 +281,13 @@ class BaseChatHandler:
             f"Sorry, an error occurred. Details below:\n\n```\n{formatted_e}\n```"
         )
         self.reply(response, message)
-    
+
     def write_message(self, body: str, id: Optional[str] = None) -> None:
         """[Jupyter Chat only] Writes a message to the YChat shared document
         that this chat handler is assigned to."""
         if not self.ychat:
             return
-        
+
         bot = self.ychat.get_user(BOT["username"])
         if not bot:
             self.ychat.set_user(BOT)
@@ -422,9 +418,7 @@ class BaseChatHandler:
         TODO: Simplify it by only modifying the awareness as soon as jupyterlab chat
         is the only used chat.
         """
-        pending_msg = self.start_pending(
-            text, human_msg=human_msg, ellipsis=ellipsis
-        )
+        pending_msg = self.start_pending(text, human_msg=human_msg, ellipsis=ellipsis)
         try:
             yield pending_msg
         finally:
@@ -501,9 +495,7 @@ class BaseChatHandler:
         else:
             return self.root_dir
 
-    def send_help_message(
-        self, human_msg: Optional[HumanChatMessage] = None
-    ) -> None:
+    def send_help_message(self, human_msg: Optional[HumanChatMessage] = None) -> None:
         """Sends a help message to all connected clients."""
         lm_provider = self.config_manager.lm_provider
         unsupported_slash_commands = (

--- a/packages/jupyter-ai/jupyter_ai/chat_handlers/clear.py
+++ b/packages/jupyter-ai/jupyter_ai/chat_handlers/clear.py
@@ -1,7 +1,4 @@
-from typing import Optional
-
 from jupyter_ai.models import ClearRequest
-from jupyterlab_chat.ychat import YChat
 
 from .base import BaseChatHandler, SlashCommandRoutingType
 
@@ -19,11 +16,11 @@ class ClearChatHandler(BaseChatHandler):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
-    async def process_message(self, _, chat: Optional[YChat]):
+    async def process_message(self, _):
         # Clear chat by triggering `RootChatHandler.on_clear_request()`.
         for handler in self._root_chat_handlers.values():
             if not handler:
                 continue
 
-            handler.on_clear_request(ClearRequest(target=None))
+            handler.on_clear_request(ClearRequest())
             break

--- a/packages/jupyter-ai/jupyter_ai/chat_handlers/default.py
+++ b/packages/jupyter-ai/jupyter_ai/chat_handlers/default.py
@@ -1,9 +1,8 @@
 import asyncio
-from typing import Dict, Optional, Type
+from typing import Dict, Type
 
 from jupyter_ai.models import HumanChatMessage
 from jupyter_ai_magics.providers import BaseProvider
-from jupyterlab_chat.ychat import YChat
 from langchain_core.runnables import ConfigurableFieldSpec
 from langchain_core.runnables.history import RunnableWithMessageHistory
 
@@ -54,7 +53,7 @@ class DefaultChatHandler(BaseChatHandler):
             )
         self.llm_chain = runnable
 
-    async def process_message(self, message: HumanChatMessage, chat: Optional[YChat]):
+    async def process_message(self, message: HumanChatMessage):
         self.get_llm_chain()
         assert self.llm_chain
 
@@ -64,12 +63,12 @@ class DefaultChatHandler(BaseChatHandler):
             try:
                 context_prompt = await self.make_context_prompt(message)
             except ContextProviderException as e:
-                self.reply(str(e), chat, message)
+                self.reply(str(e), message)
                 return
             inputs["context"] = context_prompt
             inputs["input"] = self.replace_prompt(inputs["input"])
 
-        await self.stream_reply(inputs, message, chat=chat)
+        await self.stream_reply(inputs, message)
 
     async def make_context_prompt(self, human_msg: HumanChatMessage) -> str:
         return "\n\n".join(

--- a/packages/jupyter-ai/jupyter_ai/chat_handlers/export.py
+++ b/packages/jupyter-ai/jupyter_ai/chat_handlers/export.py
@@ -1,10 +1,9 @@
 import argparse
 import os
 from datetime import datetime
-from typing import List, Optional
+from typing import List
 
 from jupyter_ai.models import AgentChatMessage, AgentStreamMessage, HumanChatMessage
-from jupyterlab_chat.ychat import YChat
 
 from .base import BaseChatHandler, SlashCommandRoutingType
 
@@ -32,11 +31,11 @@ class ExportChatHandler(BaseChatHandler):
             return ""
 
     # Write the chat history to a markdown file with a timestamp
-    async def process_message(self, message: HumanChatMessage, chat: Optional[YChat]):
+    async def process_message(self, message: HumanChatMessage):
         markdown_content = "\n\n".join(
             self.chat_message_to_markdown(msg) for msg in self._chat_history
         )
-        args = self.parse_args(message, chat)
+        args = self.parse_args(message)
         chat_filename = (  # if no filename, use "chat_history" + timestamp
             args.path[0]
             if (args.path and args.path[0] != "")
@@ -47,4 +46,4 @@ class ExportChatHandler(BaseChatHandler):
         )  # Do not use timestamp if filename is entered as argument
         with open(chat_file, "w") as chat_history:
             chat_history.write(markdown_content)
-        self.reply(f"File saved to `{chat_file}`", chat)
+        self.reply(f"File saved to `{chat_file}`")

--- a/packages/jupyter-ai/jupyter_ai/chat_handlers/fix.py
+++ b/packages/jupyter-ai/jupyter_ai/chat_handlers/fix.py
@@ -1,8 +1,7 @@
-from typing import Dict, Optional, Type
+from typing import Dict, Type
 
 from jupyter_ai.models import CellWithErrorSelection, HumanChatMessage
 from jupyter_ai_magics.providers import BaseProvider
-from jupyterlab_chat.ychat import YChat
 from langchain.prompts import PromptTemplate
 
 from .base import BaseChatHandler, SlashCommandRoutingType
@@ -80,11 +79,10 @@ class FixChatHandler(BaseChatHandler):
         runnable = prompt_template | llm  # type:ignore
         self.llm_chain = runnable
 
-    async def process_message(self, message: HumanChatMessage, chat: Optional[YChat]):
+    async def process_message(self, message: HumanChatMessage):
         if not (message.selection and message.selection.type == "cell-with-error"):
             self.reply(
                 "`/fix` requires an active code cell with error output. Please click on a cell with error output and retry.",
-                chat,
                 message,
             )
             return
@@ -106,5 +104,5 @@ class FixChatHandler(BaseChatHandler):
             "error_value": selection.error.value,
         }
         await self.stream_reply(
-            inputs, message, pending_msg="Analyzing error", chat=chat
+            inputs, message, pending_msg="Analyzing error"
         )

--- a/packages/jupyter-ai/jupyter_ai/chat_handlers/fix.py
+++ b/packages/jupyter-ai/jupyter_ai/chat_handlers/fix.py
@@ -103,6 +103,4 @@ class FixChatHandler(BaseChatHandler):
             "error_name": selection.error.name,
             "error_value": selection.error.value,
         }
-        await self.stream_reply(
-            inputs, message, pending_msg="Analyzing error"
-        )
+        await self.stream_reply(inputs, message, pending_msg="Analyzing error")

--- a/packages/jupyter-ai/jupyter_ai/chat_handlers/generate.py
+++ b/packages/jupyter-ai/jupyter_ai/chat_handlers/generate.py
@@ -273,9 +273,7 @@ class GenerateChatHandler(BaseChatHandler):
         response = f"""🎉 I have created your notebook and saved it to the location {final_path}. I am still learning how to create notebooks, so please review all code before running it."""
         self.reply(response, message)
 
-    async def handle_exc(
-        self, e: Exception, message: HumanChatMessage
-    ):
+    async def handle_exc(self, e: Exception, message: HumanChatMessage):
         timestamp = time.strftime("%Y-%m-%d-%H.%M.%S")
         default_log_dir = Path(self.output_dir) / "jupyter-ai-logs"
         log_dir = self.log_dir or default_log_dir

--- a/packages/jupyter-ai/jupyter_ai/chat_handlers/generate.py
+++ b/packages/jupyter-ai/jupyter_ai/chat_handlers/generate.py
@@ -9,7 +9,6 @@ import nbformat
 from jupyter_ai.chat_handlers import BaseChatHandler, SlashCommandRoutingType
 from jupyter_ai.models import HumanChatMessage
 from jupyter_ai_magics.providers import BaseProvider
-from jupyterlab_chat.ychat import YChat
 from langchain.chains import LLMChain
 from langchain.llms import BaseLLM
 from langchain.output_parsers import PydanticOutputParser
@@ -263,19 +262,19 @@ class GenerateChatHandler(BaseChatHandler):
         nbformat.write(notebook, final_path)
         return final_path
 
-    async def process_message(self, message: HumanChatMessage, chat: Optional[YChat]):
+    async def process_message(self, message: HumanChatMessage):
         self.get_llm_chain()
 
         # first send a verification message to user
         response = "👍 Great, I will get started on your notebook. It may take a few minutes, but I will reply here when the notebook is ready. In the meantime, you can continue to ask me other questions."
-        self.reply(response, chat, message)
+        self.reply(response, message)
 
         final_path = await self._generate_notebook(prompt=message.body)
         response = f"""🎉 I have created your notebook and saved it to the location {final_path}. I am still learning how to create notebooks, so please review all code before running it."""
-        self.reply(response, chat, message)
+        self.reply(response, message)
 
     async def handle_exc(
-        self, e: Exception, message: HumanChatMessage, chat: Optional[YChat]
+        self, e: Exception, message: HumanChatMessage
     ):
         timestamp = time.strftime("%Y-%m-%d-%H.%M.%S")
         default_log_dir = Path(self.output_dir) / "jupyter-ai-logs"
@@ -286,4 +285,4 @@ class GenerateChatHandler(BaseChatHandler):
             traceback.print_exc(file=log)
 
         response = f"An error occurred while generating the notebook. The error details have been saved to `./{log_path}`.\n\nTry running `/generate` again, as some language models require multiple attempts before a notebook is generated."
-        self.reply(response, chat, message)
+        self.reply(response, message)

--- a/packages/jupyter-ai/jupyter_ai/chat_handlers/help.py
+++ b/packages/jupyter-ai/jupyter_ai/chat_handlers/help.py
@@ -1,7 +1,4 @@
-from typing import Optional
-
 from jupyter_ai.models import HumanChatMessage
-from jupyterlab_chat.ychat import YChat
 
 from .base import BaseChatHandler, SlashCommandRoutingType
 
@@ -18,5 +15,5 @@ class HelpChatHandler(BaseChatHandler):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
-    async def process_message(self, message: HumanChatMessage, chat: Optional[YChat]):
-        self.send_help_message(chat, message)
+    async def process_message(self, message: HumanChatMessage):
+        self.send_help_message(message)

--- a/packages/jupyter-ai/jupyter_ai/chat_handlers/learn.py
+++ b/packages/jupyter-ai/jupyter_ai/chat_handlers/learn.py
@@ -143,9 +143,7 @@ class LearnChatHandler(BaseChatHandler):
 
         if args.delete:
             self.delete()
-            self.reply(
-                f"👍 I have deleted everything I previously learned.", message
-            )
+            self.reply(f"👍 I have deleted everything I previously learned.", message)
             return
 
         if args.list:
@@ -205,9 +203,7 @@ class LearnChatHandler(BaseChatHandler):
         # delete and relearn index if embedding model was changed
         await self.delete_and_relearn()
 
-        with self.pending(
-            f"Loading and splitting files for {load_path}", message
-        ):
+        with self.pending(f"Loading and splitting files for {load_path}", message):
             try:
                 await self.learn_dir(
                     load_path, args.chunk_size, args.chunk_overlap, args.all_files

--- a/packages/jupyter-ai/jupyter_ai/chat_handlers/learn.py
+++ b/packages/jupyter-ai/jupyter_ai/chat_handlers/learn.py
@@ -21,7 +21,6 @@ from jupyter_ai.models import (
 )
 from jupyter_core.paths import jupyter_data_dir
 from jupyter_core.utils import ensure_dir_exists
-from jupyterlab_chat.ychat import YChat
 from langchain.schema import BaseRetriever, Document
 from langchain.text_splitter import (
     LatexTextSplitter,
@@ -129,29 +128,28 @@ class LearnChatHandler(BaseChatHandler):
             )
             self.log.error(e)
 
-    async def process_message(self, message: HumanChatMessage, chat: Optional[YChat]):
+    async def process_message(self, message: HumanChatMessage):
         # If no embedding provider has been selected
         em_provider_cls, em_provider_args = self.get_embedding_provider()
         if not em_provider_cls:
             self.reply(
                 "Sorry, please select an embedding provider before using the `/learn` command.",
-                chat,
             )
             return
 
-        args = self.parse_args(message, chat)
+        args = self.parse_args(message)
         if args is None:
             return
 
         if args.delete:
             self.delete()
             self.reply(
-                f"👍 I have deleted everything I previously learned.", chat, message
+                f"👍 I have deleted everything I previously learned.", message
             )
             return
 
         if args.list:
-            self.reply(self._build_list_response(), chat)
+            self.reply(self._build_list_response())
             return
 
         if args.remote:
@@ -162,7 +160,6 @@ class LearnChatHandler(BaseChatHandler):
                     args.path = [arxiv_to_text(id, self.output_dir)]
                     self.reply(
                         f"Learning arxiv file with id **{id}**, saved in **{args.path[0]}**.",
-                        chat,
                         message,
                     )
                 except ModuleNotFoundError as e:
@@ -170,7 +167,6 @@ class LearnChatHandler(BaseChatHandler):
                     self.reply(
                         "No `arxiv` package found. "
                         "Install with `pip install arxiv`.",
-                        chat,
                     )
                     return
                 except Exception as e:
@@ -178,7 +174,6 @@ class LearnChatHandler(BaseChatHandler):
                     self.reply(
                         "An error occurred while processing the arXiv file. "
                         f"Please verify that the arxiv id {id} is correct.",
-                        chat,
                     )
                     return
 
@@ -194,7 +189,7 @@ class LearnChatHandler(BaseChatHandler):
                 "- Learn on files in the root directory: `/learn *`\n"
                 "- Learn all python files under the root directory recursively: `/learn **/*.py`"
             )
-            self.reply(f"{self.parser.format_usage()}\n\n {no_path_arg_message}", chat)
+            self.reply(f"{self.parser.format_usage()}\n\n {no_path_arg_message}")
             return
         short_path = args.path[0]
         load_path = os.path.join(self.output_dir, short_path)
@@ -204,14 +199,14 @@ class LearnChatHandler(BaseChatHandler):
                 next(iglob(load_path))
             except StopIteration:
                 response = f"Sorry, that path doesn't exist: {load_path}"
-                self.reply(response, chat, message)
+                self.reply(response, message)
                 return
 
         # delete and relearn index if embedding model was changed
-        await self.delete_and_relearn(chat)
+        await self.delete_and_relearn()
 
         with self.pending(
-            f"Loading and splitting files for {load_path}", message, chat=chat
+            f"Loading and splitting files for {load_path}", message
         ):
             try:
                 await self.learn_dir(
@@ -228,7 +223,7 @@ class LearnChatHandler(BaseChatHandler):
                     You can ask questions about these docs by prefixing your message with **/ask**.""" % (
                     load_path.replace("*", r"\*")
                 )
-        self.reply(response, chat, message)
+        self.reply(response, message)
 
     def _build_list_response(self):
         if not self.metadata.dirs:
@@ -282,7 +277,7 @@ class LearnChatHandler(BaseChatHandler):
             )
         self.metadata.dirs = dirs
 
-    async def delete_and_relearn(self, chat: Optional[YChat] = None):
+    async def delete_and_relearn(self):
         """Delete the vector store and relearn all indexed directories if
         necessary. If the embedding model is unchanged, this method does
         nothing."""
@@ -309,11 +304,11 @@ class LearnChatHandler(BaseChatHandler):
         documents you had previously submitted for learning. Please wait to use
         the **/ask** command until I am done with this task."""
 
-        self.reply(message, chat)
+        self.reply(message)
 
         metadata = self.metadata
         self.delete()
-        await self.relearn(metadata, chat)
+        await self.relearn(metadata)
         self.prev_em_id = curr_em_id
 
     def delete(self):
@@ -327,7 +322,7 @@ class LearnChatHandler(BaseChatHandler):
             if os.path.isfile(path):
                 os.remove(path)
 
-    async def relearn(self, metadata: IndexMetadata, chat: Optional[YChat]):
+    async def relearn(self, metadata: IndexMetadata):
         # Index all dirs in the metadata
         if not metadata.dirs:
             return
@@ -347,7 +342,7 @@ class LearnChatHandler(BaseChatHandler):
         message = f"""🎉 I am done learning docs in these directories:
         {dir_list} I am ready to answer questions about them.
         You can ask me about these documents by starting your message with **/ask**."""
-        self.reply(message, chat)
+        self.reply(message)
 
     def create(
         self,

--- a/packages/jupyter-ai/jupyter_ai/constants.py
+++ b/packages/jupyter-ai/jupyter_ai/constants.py
@@ -1,0 +1,8 @@
+# The BOT currently has a fixed username, because this username is used has key in chats,
+# it needs to constant. Do we need to change it ?
+BOT = {
+    "username": "5f6a7570-7974-6572-6e61-75742d626f74",
+    "name": "Jupyternaut",
+    "display_name": "Jupyternaut",
+    "initials": "J",
+}

--- a/packages/jupyter-ai/jupyter_ai/extension.py
+++ b/packages/jupyter-ai/jupyter_ai/extension.py
@@ -266,7 +266,7 @@ class AiExtension(ExtensionApp):
         self.log.info(f"Connecting to a chat room with room ID: {room_id}.")
 
         # get YChat document associated with the room
-        ychat = await self.get_chat(data["room"])
+        ychat = await self.get_chat(room_id)
         if ychat is None:
             return
 

--- a/packages/jupyter-ai/jupyter_ai/extension.py
+++ b/packages/jupyter-ai/jupyter_ai/extension.py
@@ -6,6 +6,7 @@ import uuid
 from functools import partial
 from typing import Dict, Optional
 
+import traitlets
 from dask.distributed import Client as DaskClient
 from importlib_metadata import entry_points
 from jupyter_ai.chat_handlers.learn import Retriever
@@ -18,7 +19,6 @@ from jupyter_server.utils import url_path_join
 from jupyterlab_chat.ychat import YChat
 from pycrdt import ArrayEvent
 from tornado.web import StaticFileHandler
-import traitlets
 from traitlets import Integer, List, Unicode
 
 from .chat_handlers import (
@@ -237,7 +237,7 @@ class AiExtension(ExtensionApp):
         """
         Nested dictionary that returns the dedicated chat handler instance that
         should be used, given the room ID and command ID respectively.
-        
+
         Example: `self.chat_handlers_by_room[<room_id>]` yields the set of chat
         handlers dedicated to the room identified by `<room_id>`.
         """
@@ -249,11 +249,11 @@ class AiExtension(ExtensionApp):
         self.event_logger.add_listener(
             schema_id=JUPYTER_COLLABORATION_EVENTS_URI, listener=self.connect_chat
         )
-    
+
     async def connect_chat(
         self, logger: EventLogger, schema_id: str, data: dict
     ) -> None:
-        # ignore events that are not chat room initialization events 
+        # ignore events that are not chat room initialization events
         if not (
             data["room"].startswith("text:chat:")
             and data["action"] == "initialize"
@@ -276,7 +276,7 @@ class AiExtension(ExtensionApp):
         )
         if ychat.awareness is not None:
             ychat.awareness.set_local_state_field("user", BOT)
-        
+
         # initialize chat handlers for new chat
         self.chat_handlers_by_room[room_id] = self._init_chat_handlers(ychat)
 
@@ -504,11 +504,13 @@ class AiExtension(ExtensionApp):
             await dask_client.close()
             self.log.debug("Closed Dask client.")
 
-    def _init_chat_handlers(self, ychat: Optional[YChat] = None) -> Dict[str, BaseChatHandler]:
+    def _init_chat_handlers(
+        self, ychat: Optional[YChat] = None
+    ) -> Dict[str, BaseChatHandler]:
         """
         Initializes a set of chat handlers. May accept a YChat instance for
         collaborative chats.
-        
+
         TODO: Make `ychat` required once Jupyter Chat migration is complete.
         """
         eps = entry_points()
@@ -528,7 +530,7 @@ class AiExtension(ExtensionApp):
             "chat_handlers": chat_handlers,
             "context_providers": self.settings["jai_context_providers"],
             "message_interrupted": self.settings["jai_message_interrupted"],
-            "ychat": ychat
+            "ychat": ychat,
         }
         default_chat_handler = DefaultChatHandler(**chat_handler_kwargs)
         clear_chat_handler = ClearChatHandler(**chat_handler_kwargs)

--- a/packages/jupyter-ai/jupyter_ai/tests/test_handlers.py
+++ b/packages/jupyter-ai/jupyter_ai/tests/test_handlers.py
@@ -19,7 +19,6 @@ from jupyter_ai.models import (
     Persona,
 )
 from jupyter_ai_magics import BaseProvider
-from jupyterlab_chat.ychat import YChat
 from langchain_community.llms import FakeListLLM
 from tornado.httputil import HTTPServerRequest
 from tornado.web import Application
@@ -65,11 +64,6 @@ class TestDefaultChatHandler(DefaultChatHandler):
         root_handler = mock.create_autospec(RootChatHandler)
         root_handler.broadcast_message = broadcast_message
 
-        def write_message(
-            self, chat: YChat, body: str, id: Optional[str] = None
-        ) -> str:
-            return id or ""
-
         super().__init__(
             log=logging.getLogger(__name__),
             config_manager=config_manager,
@@ -84,7 +78,7 @@ class TestDefaultChatHandler(DefaultChatHandler):
             chat_handlers={},
             context_providers={},
             message_interrupted={},
-            write_message=write_message,
+            ychat=None
         )
 
 
@@ -127,7 +121,7 @@ async def test_default_closes_pending_on_success(human_chat_message):
             "should_raise": False,
         },
     )
-    await handler.process_message(human_chat_message, None)
+    await handler.process_message(human_chat_message)
 
     # >=2 because there are additional stream messages that follow
     assert len(handler.messages) >= 2
@@ -144,7 +138,7 @@ async def test_default_closes_pending_on_error(human_chat_message):
         },
     )
     with pytest.raises(TestException):
-        await handler.process_message(human_chat_message, None)
+        await handler.process_message(human_chat_message)
 
     assert len(handler.messages) == 2
     assert isinstance(handler.messages[0], PendingMessage)

--- a/packages/jupyter-ai/jupyter_ai/tests/test_handlers.py
+++ b/packages/jupyter-ai/jupyter_ai/tests/test_handlers.py
@@ -78,7 +78,7 @@ class TestDefaultChatHandler(DefaultChatHandler):
             chat_handlers={},
             context_providers={},
             message_interrupted={},
-            ychat=None
+            ychat=None,
         )
 
 


### PR DESCRIPTION
## Description

- Makes chat handlers non-singletons in Jupyter AI. Each chat handler is dedicated to at most 1 `YChat` instance.
- Makes `YChat` an instance attribute instead of a local variable that gets forwarded across methods.
- Reverts most changes to chat handlers (except for the base class).

## Demo

https://github.com/user-attachments/assets/ecd8e027-b5da-4f49-9edf-6f0c5eb71d73


